### PR TITLE
Make account name consistent with notebook on jobs

### DIFF
--- a/tutorials/basics/021_artefacts/jobscript.slurm
+++ b/tutorials/basics/021_artefacts/jobscript.slurm
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S bash -l
-#SBATCH --account=lp_multiscale_physics
+#SBATCH --account=lp_tutorial
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1

--- a/tutorials/basics/021_artefacts/jobscript_parallel.slurm
+++ b/tutorials/basics/021_artefacts/jobscript_parallel.slurm
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S bash -l
-#SBATCH --account=lp_multiscale_physics
+#SBATCH --account=lp_tutorial
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1

--- a/tutorials/basics/021_artefacts/jobscript_parallel_failuers.slurm
+++ b/tutorials/basics/021_artefacts/jobscript_parallel_failuers.slurm
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S bash -l
-#SBATCH --account=lp_multiscale_physics
+#SBATCH --account=lp_tutorial
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1

--- a/tutorials/basics/021_atools.ipynb
+++ b/tutorials/basics/021_atools.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "```bash\n",
     "#!/usr/bin/env -S bash -l\n",
-    "#SBATCH --account=lp_multiscale_physics\n",
+    "#SBATCH --account=lp_tutorial\n",
     "#SBATCH --nodes=1\n",
     "#SBATCH --ntasks=1\n",
     "#SBATCH --cpus-per-task=1\n",
@@ -126,7 +126,7 @@
     "\n",
     "```bash\n",
     "#!/usr/bin/env -S bash -l\n",
-    "#SBATCH --account=lp_multiscale_physics\n",
+    "#SBATCH --account=lp_tutorial\n",
     "#SBATCH --nodes=1\n",
     "#SBATCH --ntasks=1\n",
     "#SBATCH --cpus-per-task=1\n",
@@ -594,7 +594,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Bash (ipykernel)",
+   "display_name": "Bash",
    "language": "bash",
    "name": "bash"
   },


### PR DESCRIPTION
For consistency, the original account name has been replaced
by the one used in the notebook on jobs, i.e., `lp_tutorial`.

This change was also made in the artefacts.
